### PR TITLE
Revert "MacOSX fix: -arch flag was not being passed to the linker, as it should."

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -366,7 +366,7 @@ class boost(Generator):
     @property
     def b2_arch_flags(self):
         if self.b2_os == 'darwin' or self.b2_os == 'iphone':
-            return '<linkflags>"-arch {0}"\n<flags>"-arch {0}"'.format(self.apple_arch)
+            return '<flags>"-arch {0}"'.format(self.apple_arch)
         return ''
 
     @property


### PR DESCRIPTION
Reverts bincrafters/conan-boost-generator#4

Per @grafikrobot this caused several libraries to fail build.  It's very likely a good PR, we just need time to work through all the failures over next few weeks. Expect for next release. 