### PR TITLE
Fix for Python3 subprocess returning bytes rather than str.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -2,6 +2,7 @@ from conans.model.conan_generator import Generator
 from conans import ConanFile, tools, load
 from io import StringIO
 import glob
+import locale
 import subprocess
 import os
 
@@ -358,7 +359,7 @@ class boost(Generator):
         return None
 
     def command_output(self, command):
-        return subprocess.check_output(command, shell=False).strip()
+        return subprocess.check_output(command, shell=False, encoding=locale.getpreferredencoding()).strip()
 
     @property
     def apply_isysroot(self):


### PR DESCRIPTION
This results in a b-prefix when formatting using {} which implicitly
uses the repr() of a bytes object.

The fix here is to set the encoding for subprocess.check_output to be whatever the current encoding is so it will return str instead of bytes.